### PR TITLE
fix: remove empty id in pages wysiwyg form

### DIFF
--- a/www/View/dynamic-page.view.php
+++ b/www/View/dynamic-page.view.php
@@ -3,7 +3,6 @@
     <?php $this->partialInclude("wysiwyg",
         [
             "class" => "p-8 card",
-            "id" => "",
             "data" => $page->getContent(),
             "readOnly" => "true"
         ]) ?>


### PR DESCRIPTION
# Pull Request

### Description

Litlte fix to remove an id field in the pages wysiwyg form that broke the code

### Pull Request Type

-   [ ] Feature
-   [x] Fix
-   [ ] Hotfix
-   [ ] Docker

### By pushing this PR i assumed that i've:

-   [x] Tested My Code
-   [x] Did it a way it is reusable
-   [x] Documented the coode
-   [x] Moved the Trello Card
